### PR TITLE
Make hidden contenteditable also hidden for screenreaders

### DIFF
--- a/paste.coffee
+++ b/paste.coffee
@@ -44,6 +44,8 @@ dataURLtoBlob = (dataURL, sliceSize=512) ->
 createHiddenEditable = ->
   $(document.createElement 'div')
   .attr 'contenteditable', true
+  .attr 'aria-hidden', true
+  .attr 'tabindex', -1
   .css
     width: 1
     height: 1


### PR DESCRIPTION
I added `tabindex="-1"` and `aria-hidden="true"` to make screenreaders ignore the hidden `contenteditable`.

Output before (in "browse mode"): `blank.`
Output before (in "focus mode"): `section editable. blank.`

Both outputs are gone with the 2 attributes above.

Tested with [NVDA screenreader](http://www.nvaccess.org/).

Still, there is a nasty output after pasting a screenshot: `section editable. blank.` I guess it's because the element receives focus by JavaScript when pasting. I tried adding `.attr 'aria-label', 'screenshot pasted'` but the result isn't much better: `screenshot pasted. section editable. blank.`. Maybe there is a way to "do the magic stuff" without setting the focus on the `contenteditable` div?

Anyways, great work, very useful! :+1: 