### PR TITLE
Move all dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/layerssss/paste.js/issues"
   },
   "homepage": "https://github.com/layerssss/paste.js#readme",
-  "dependencies": {
+  "devDependencies": {
     "browser-sync": "^2.14.3",
     "coffee-script": "^1.10.0",
     "concurrently": "^2.2.0",


### PR DESCRIPTION
So they won't get installed on `npm install --production`.