### PR TITLE
Add 'files' array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,11 @@
     "coffee-script": "^1.10.0",
     "concurrently": "^2.2.0",
     "wait-run": "^1.2.0"
-  }
+  },
+  "files": [
+    "paste.js",
+    "README.md",
+    "README_ru.md",
+    "LICENCE"
+  ]
 }


### PR DESCRIPTION
This limits the files that are published to npm on `npm publish`. It's generally best to include only the minimum amount of code and documentation in a npm package.