### PR TITLE
Add pasteImageStart and pasteImageEnd events

### DIFF
--- a/paste.coffee
+++ b/paste.coffee
@@ -205,6 +205,7 @@ class Paste
     if src.match /^webkit\-fake\-url\:\/\//
       return @_target.trigger 'pasteImageError',
         message: "You are trying to paste an image in Safari, however we are unable to retieve its data."
+    @_target.trigger 'pasteImageStart'
     loader = new Image()
     loader.crossOrigin = "anonymous"
     loader.onload = =>
@@ -223,10 +224,12 @@ class Paste
           dataURL: dataURL
           width: loader.width
           height: loader.height
+      @_target.trigger 'pasteImageEnd'
     loader.onerror = =>
       @_target.trigger 'pasteImageError',
         message: "Failed to get image from: #{src}"
         url: src
+      @_target.trigger 'pasteImageEnd'
     loader.src = src
 
   _checkImagesInContainer: (cb)->

--- a/paste.js
+++ b/paste.js
@@ -330,6 +330,7 @@ https://github.com/layerssss/paste.js
           message: "You are trying to paste an image in Safari, however we are unable to retieve its data."
         });
       }
+      this._target.trigger('pasteImageStart');
       loader = new Image();
       loader.crossOrigin = "anonymous";
       loader.onload = (function(_this) {
@@ -346,21 +347,23 @@ https://github.com/layerssss/paste.js
             blob = dataURLtoBlob(dataURL);
           } catch (error) {}
           if (dataURL) {
-            return _this._target.trigger('pasteImage', {
+            _this._target.trigger('pasteImage', {
               blob: blob,
               dataURL: dataURL,
               width: loader.width,
               height: loader.height
             });
           }
+          return _this._target.trigger('pasteImageEnd');
         };
       })(this);
       loader.onerror = (function(_this) {
         return function() {
-          return _this._target.trigger('pasteImageError', {
+          _this._target.trigger('pasteImageError', {
             message: "Failed to get image from: " + src,
             url: src
           });
+        return _this._target.trigger('pasteImageEnd');
         };
       })(this);
       return loader.src = src;


### PR DESCRIPTION
Since large images have a noticeable delay when the user pastes, these events can be useful to display a loading dialog or simply stop handling consecutive pastes until the first one is complete.