### PR TITLE
Allow setting + passing data using originalEvent

### DIFF
--- a/paste.coffee
+++ b/paste.coffee
@@ -162,6 +162,7 @@ class Paste
       .addClass 'pastable'
     @_container.on 'paste', (ev)=>
       return ev.preventDefault() unless ev.currentTarget == ev.target
+      @originalEvent = (if ev.originalEvent != null then ev.originalEvent else null)
       @_paste_event_fired = true
       if ev.originalEvent?.clipboardData?
         clipboardData = ev.originalEvent.clipboardData
@@ -171,33 +172,33 @@ class Paste
             if item.type.match /^image\//
               reader = new FileReader()
               reader.onload = (event)=>
-                @_handleImage event.target.result, (if ev.originalEvent != null then ev.originalEvent else null)
+                @_handleImage event.target.result, @originalEvent
               try
                 reader.readAsDataURL item.getAsFile()
               ev.preventDefault()
               break
             if item.type == 'text/plain'
               item.getAsString (string)=>
-                @_target.trigger 'pasteText', text: string, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+                @_target.trigger 'pasteText', text: string, originalEvent: @originalEvent
         else
           # Firefox & Safari(text-only)
           if -1 != Array.prototype.indexOf.call clipboardData.types, 'text/plain'
             text = clipboardData.getData 'Text'
             setTimeout =>
-              @_target.trigger 'pasteText', text: text, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+              @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             , 1
           @_checkImagesInContainer (src)=>
-            @_handleImage src, (if ev.originalEvent != null then ev.originalEvent else null)
+            @_handleImage src, @originalEvent
       # IE
       if clipboardData = window.clipboardData
         if (text = clipboardData.getData 'Text')?.length
           setTimeout =>
-            @_target.trigger 'pasteText', text: text, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+            @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             @_target.trigger '_pasteCheckContainerDone'
           , 1
         else
           for file in clipboardData.files
-            @_handleImage URL.createObjectURL(file), (if ev.originalEvent != null then ev.originalEvent else null)
+            @_handleImage URL.createObjectURL(file), @originalEvent
           @_checkImagesInContainer (src)->
       null
 

--- a/paste.js
+++ b/paste.js
@@ -261,6 +261,7 @@ https://github.com/layerssss/paste.js
           if (ev.currentTarget !== ev.target) {
             return ev.preventDefault();
           }
+          _this.originalEvent = (ev.originalEvent !== null ? ev.originalEvent : null);
           _this._paste_event_fired = true;
           if (((ref = ev.originalEvent) != null ? ref.clipboardData : void 0) != null) {
             clipboardData = ev.originalEvent.clipboardData;
@@ -271,7 +272,7 @@ https://github.com/layerssss/paste.js
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
-                    return _this._handleImage(event.target.result, (ev.originalEvent !== null ? ev.originalEvent : null));
+                    return _this._handleImage(event.target.result, _this.originalEvent);
                   };
                   try {
                     reader.readAsDataURL(item.getAsFile());
@@ -283,7 +284,7 @@ https://github.com/layerssss/paste.js
                   item.getAsString(function(string) {
                     return _this._target.trigger('pasteText', {
                       text: string,
-                      originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                      originalEvent: _this.originalEvent
                     });
                   });
                 }
@@ -294,12 +295,12 @@ https://github.com/layerssss/paste.js
                 setTimeout(function() {
                   return _this._target.trigger('pasteText', {
                     text: text,
-                    originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                    originalEvent: _this.originalEvent
                   });
                 }, 1);
               }
               _this._checkImagesInContainer(function(src) {
-                return _this._handleImage(src, (ev.originalEvent !== null ? ev.originalEvent : null));
+                return _this._handleImage(src, _this.originalEvent);
               });
             }
           }
@@ -308,7 +309,7 @@ https://github.com/layerssss/paste.js
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
                   text: text,
-                  originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                  originalEvent: _this.originalEvent
                 });
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
@@ -316,7 +317,7 @@ https://github.com/layerssss/paste.js
               ref3 = clipboardData.files;
               for (k = 0, len1 = ref3.length; k < len1; k++) {
                 file = ref3[k];
-                _this._handleImage(URL.createObjectURL(file), (ev.originalEvent !== null ? ev.originalEvent : null));
+                _this._handleImage(URL.createObjectURL(file), _this.originalEvent);
               }
               _this._checkImagesInContainer(function(src) {});
             }

--- a/paste.js
+++ b/paste.js
@@ -271,7 +271,7 @@ https://github.com/layerssss/paste.js
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
-                    return _this._handleImage(event.target.result);
+                    return _this._handleImage(event.target.result, (ev.originalEvent !== null ? ev.originalEvent : null));
                   };
                   try {
                     reader.readAsDataURL(item.getAsFile());
@@ -282,7 +282,8 @@ https://github.com/layerssss/paste.js
                 if (item.type === 'text/plain') {
                   item.getAsString(function(string) {
                     return _this._target.trigger('pasteText', {
-                      text: string
+                      text: string,
+                      originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                     });
                   });
                 }
@@ -292,12 +293,13 @@ https://github.com/layerssss/paste.js
                 text = clipboardData.getData('Text');
                 setTimeout(function() {
                   return _this._target.trigger('pasteText', {
-                    text: text
+                    text: text,
+                    originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                   });
                 }, 1);
               }
               _this._checkImagesInContainer(function(src) {
-                return _this._handleImage(src);
+                return _this._handleImage(src, (ev.originalEvent !== null ? ev.originalEvent : null));
               });
             }
           }
@@ -305,7 +307,8 @@ https://github.com/layerssss/paste.js
             if ((ref2 = (text = clipboardData.getData('Text'))) != null ? ref2.length : void 0) {
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
-                  text: text
+                  text: text,
+                  originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                 });
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
@@ -313,7 +316,7 @@ https://github.com/layerssss/paste.js
               ref3 = clipboardData.files;
               for (k = 0, len1 = ref3.length; k < len1; k++) {
                 file = ref3[k];
-                _this._handleImage(URL.createObjectURL(file));
+                _this._handleImage(URL.createObjectURL(file), (ev.originalEvent !== null ? ev.originalEvent : null));
               }
               _this._checkImagesInContainer(function(src) {});
             }
@@ -323,7 +326,7 @@ https://github.com/layerssss/paste.js
       })(this));
     }
 
-    Paste.prototype._handleImage = function(src) {
+    Paste.prototype._handleImage = function(src, e) {
       var loader;
       if (src.match(/^webkit\-fake\-url\:\/\//)) {
         return this._target.trigger('pasteImageError', {
@@ -351,7 +354,8 @@ https://github.com/layerssss/paste.js
               blob: blob,
               dataURL: dataURL,
               width: loader.width,
-              height: loader.height
+              height: loader.height,
+              originalEvent: e
             });
           }
           return _this._target.trigger('pasteImageEnd');


### PR DESCRIPTION
If you want to append data (like a 'Paste ID') to pasted data, you now can set some data on the originalEvent at the `paste()` event. Data will persist on the originalEvent, allowing you to access the data on the `pasteText` and `pasteImage` event(s). Now you can match pasted text and images.

```
        $("body").pastableNonInputable()

        $('body').on('paste', function(ev){
            ev.originalEvent._myId = 1337
        })
        .on('pasteImage', function (ev, data) {
            console.log('pasteImage', data.originalEvent._myId)
        }).on('pasteText', function (ev, data) {
            console.log('pasteText', data.originalEvent._myId)
        });
```

When pasting a large image (file, .png) from the clipboard (eg. Chrome, OSX) the filename and image can be matched using the ID you've set @ the `paste` event;

Console:
```
testvanilla.html:657 pasteText 1337
testvanilla.html:642 pasteImage 1337
```