### PR TITLE
Chrome paste file: include filename, Chrome: paste RTF / HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
       $('.demo-contenteditable').pastableContenteditable();
       $('.demo').on('pasteImage', function(ev, data){
         var blobUrl = URL.createObjectURL(data.blob);
-        $('<div class="result">image: ' + data.width + ' x ' + data.height + '<img src="' + data.dataURL +'" ><a href="' + blobUrl + '">' + blobUrl + '</div>').insertAfter(this);
+        var name = data.name != null ? ', name: ' + data.name : '';
+        $('<div class="result">image: ' + data.width + ' x ' + data.height + name + '<img src="' + data.dataURL +'" ><a href="' + blobUrl + '">' + blobUrl + '</div>').insertAfter(this);
       }).on('pasteImageError', function(ev, data){
         alert('Oops: ' + data.message);
         if(data.url){
@@ -56,6 +57,10 @@
         }
       }).on('pasteText', function(ev, data){
         $('<div class="result"></div>').text('text: "' + data.text + '"').insertAfter(this);
+      }).on('pasteTextRich', function(ev, data){
+        $('<div class="result"></div>').text('rtf: "' + data.text + '"').insertAfter(this);
+      }).on('pasteTextHtml', function(ev, data){
+        $('<div class="result"></div>').text('html: "' + data.text + '"').insertAfter(this);
       });
     });
   </script>

--- a/paste.coffee
+++ b/paste.coffee
@@ -187,6 +187,7 @@ class Paste
               item.getAsString (string)=>
                 if stringIsFilename
                   pastedFilename = string
+                  @_target.trigger 'pasteText', text: string, isFilename: true, originalEvent: @originalEvent
                 else
                   @_target.trigger 'pasteText', text: string, originalEvent: @originalEvent
             if item.type == 'text/rtf'

--- a/paste.coffee
+++ b/paste.coffee
@@ -182,12 +182,13 @@ class Paste
               ev.preventDefault()
               break
             if item.type == 'text/plain'
-              if _i == 0 && clipboardData.items.length > 1 && clipboardData.items[_i + 1].type.match /^image\//
+              if _i == 0 && clipboardData.items.length > 1 && clipboardData.items[1].type.match /^image\//
                 stringIsFilename = true
+                fileType = clipboardData.items[1].type
               item.getAsString (string)=>
                 if stringIsFilename
                   pastedFilename = string
-                  @_target.trigger 'pasteText', text: string, isFilename: true, originalEvent: @originalEvent
+                  @_target.trigger 'pasteText', text: string, isFilename: true, fileType: fileType, originalEvent: @originalEvent
                 else
                   @_target.trigger 'pasteText', text: string, originalEvent: @originalEvent
             if item.type == 'text/rtf'

--- a/paste.coffee
+++ b/paste.coffee
@@ -169,6 +169,9 @@ class Paste
         if clipboardData.items
           pastedFilename = null
           # Chrome or any other browsers with DataTransfer.items implemented
+          @originalEvent.pastedTypes = []
+          for item in clipboardData.items
+            @originalEvent.pastedTypes.push(item.type)
           for item, _i in clipboardData.items
             if item.type.match /^image\//
               reader = new FileReader()

--- a/paste.coffee
+++ b/paste.coffee
@@ -162,6 +162,7 @@ class Paste
       .addClass 'pastable'
     @_container.on 'paste', (ev)=>
       return ev.preventDefault() unless ev.currentTarget == ev.target
+      @originalEvent = (if ev.originalEvent != null then ev.originalEvent else null)
       @_paste_event_fired = true
       if ev.originalEvent?.clipboardData?
         clipboardData = ev.originalEvent.clipboardData
@@ -171,33 +172,33 @@ class Paste
             if item.type.match /^image\//
               reader = new FileReader()
               reader.onload = (event)=>
-                @_handleImage event.target.result, (if ev.originalEvent != null then ev.originalEvent else null)
+                @_handleImage event.target.result, @originalEvent
               try
                 reader.readAsDataURL item.getAsFile()
               ev.preventDefault()
               break
             if item.type == 'text/plain'
               item.getAsString (string)=>
-                @_target.trigger 'pasteText', text: string, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+                @_target.trigger 'pasteText', text: string, originalEvent: @originalEvent
         else
           # Firefox & Safari(text-only)
           if -1 != Array.prototype.indexOf.call clipboardData.types, 'text/plain'
             text = clipboardData.getData 'Text'
             setTimeout =>
-              @_target.trigger 'pasteText', text: text, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+              @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             , 1
           @_checkImagesInContainer (src)=>
-            @_handleImage src, (if ev.originalEvent != null then ev.originalEvent else null)
+            @_handleImage src, @originalEvent
       # IE
       if clipboardData = window.clipboardData
         if (text = clipboardData.getData 'Text')?.length
           setTimeout =>
-            @_target.trigger 'pasteText', text: text, originalEvent: (if ev.originalEvent != null then ev.originalEvent else null)
+            @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             @_target.trigger '_pasteCheckContainerDone'
           , 1
         else
           for file in clipboardData.files
-            @_handleImage URL.createObjectURL(file), (if ev.originalEvent != null then ev.originalEvent else null)
+            @_handleImage URL.createObjectURL(file), @originalEvent
           @_checkImagesInContainer (src)->
       null
 

--- a/paste.js
+++ b/paste.js
@@ -293,7 +293,12 @@ https://github.com/layerssss/paste.js
                   }
                   item.getAsString(function(string) {
                     if (stringIsFilename) {
-                      return pastedFilename = string;
+                      pastedFilename = string;
+                      return _this._target.trigger('pasteText', {
+                        text: string,
+                        isFilename: true,
+                        originalEvent: _this.originalEvent
+                      });
                     } else {
                       return _this._target.trigger('pasteText', {
                         text: string,

--- a/paste.js
+++ b/paste.js
@@ -257,7 +257,7 @@ https://github.com/layerssss/paste.js
       this._target = $(this._target).addClass('pastable');
       this._container.on('paste', (function(_this) {
         return function(ev) {
-          var _i, clipboardData, file, item, j, k, len, len1, pastedFilename, reader, ref, ref1, ref2, ref3, stringIsFilename, text;
+          var _i, clipboardData, file, item, j, k, l, len, len1, len2, pastedFilename, reader, ref, ref1, ref2, ref3, ref4, stringIsFilename, text;
           if (ev.currentTarget !== ev.target) {
             return ev.preventDefault();
           }
@@ -267,9 +267,15 @@ https://github.com/layerssss/paste.js
             clipboardData = ev.originalEvent.clipboardData;
             if (clipboardData.items) {
               pastedFilename = null;
+              _this.originalEvent.pastedTypes = [];
               ref1 = clipboardData.items;
-              for (_i = j = 0, len = ref1.length; j < len; _i = ++j) {
-                item = ref1[_i];
+              for (j = 0, len = ref1.length; j < len; j++) {
+                item = ref1[j];
+                _this.originalEvent.pastedTypes.push(item.type);
+              }
+              ref2 = clipboardData.items;
+              for (_i = k = 0, len1 = ref2.length; k < len1; _i = ++k) {
+                item = ref2[_i];
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
@@ -329,7 +335,7 @@ https://github.com/layerssss/paste.js
             }
           }
           if (clipboardData = window.clipboardData) {
-            if ((ref2 = (text = clipboardData.getData('Text'))) != null ? ref2.length : void 0) {
+            if ((ref3 = (text = clipboardData.getData('Text'))) != null ? ref3.length : void 0) {
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
                   text: text,
@@ -338,9 +344,9 @@ https://github.com/layerssss/paste.js
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
             } else {
-              ref3 = clipboardData.files;
-              for (k = 0, len1 = ref3.length; k < len1; k++) {
-                file = ref3[k];
+              ref4 = clipboardData.files;
+              for (l = 0, len2 = ref4.length; l < len2; l++) {
+                file = ref4[l];
                 _this._handleImage(URL.createObjectURL(file), _this.originalEvent);
               }
               _this._checkImagesInContainer(function(src) {});

--- a/paste.js
+++ b/paste.js
@@ -261,6 +261,7 @@ https://github.com/layerssss/paste.js
           if (ev.currentTarget !== ev.target) {
             return ev.preventDefault();
           }
+          _this.originalEvent = (ev.originalEvent !== null ? ev.originalEvent : null);
           _this._paste_event_fired = true;
           if (((ref = ev.originalEvent) != null ? ref.clipboardData : void 0) != null) {
             clipboardData = ev.originalEvent.clipboardData;
@@ -271,7 +272,7 @@ https://github.com/layerssss/paste.js
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
-                    return _this._handleImage(event.target.result, (ev.originalEvent !== null ? ev.originalEvent : null));
+                    return _this._handleImage(event.target.result, _this.originalEvent);
                   };
                   try {
                     reader.readAsDataURL(item.getAsFile());
@@ -283,7 +284,7 @@ https://github.com/layerssss/paste.js
                   item.getAsString(function(string) {
                     return _this._target.trigger('pasteText', {
                       text: string,
-                      originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                      originalEvent: _this.originalEvent
                     });
                   });
                 }
@@ -294,12 +295,12 @@ https://github.com/layerssss/paste.js
                 setTimeout(function() {
                   return _this._target.trigger('pasteText', {
                     text: text,
-                    originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                    originalEvent: _this.originalEvent
                   });
                 }, 1);
               }
               _this._checkImagesInContainer(function(src) {
-                return _this._handleImage(src, (ev.originalEvent !== null ? ev.originalEvent : null));
+                return _this._handleImage(src, _this.originalEvent);
               });
             }
           }
@@ -308,7 +309,7 @@ https://github.com/layerssss/paste.js
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
                   text: text,
-                  originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
+                  originalEvent: _this.originalEvent
                 });
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
@@ -316,7 +317,7 @@ https://github.com/layerssss/paste.js
               ref3 = clipboardData.files;
               for (k = 0, len1 = ref3.length; k < len1; k++) {
                 file = ref3[k];
-                _this._handleImage(URL.createObjectURL(file), (ev.originalEvent !== null ? ev.originalEvent : null));
+                _this._handleImage(URL.createObjectURL(file), _this.originalEvent);
               }
               _this._checkImagesInContainer(function(src) {});
             }

--- a/paste.js
+++ b/paste.js
@@ -257,7 +257,7 @@ https://github.com/layerssss/paste.js
       this._target = $(this._target).addClass('pastable');
       this._container.on('paste', (function(_this) {
         return function(ev) {
-          var _i, clipboardData, file, item, j, k, l, len, len1, len2, pastedFilename, reader, ref, ref1, ref2, ref3, ref4, stringIsFilename, text;
+          var _i, clipboardData, file, fileType, item, j, k, l, len, len1, len2, pastedFilename, reader, ref, ref1, ref2, ref3, ref4, stringIsFilename, text;
           if (ev.currentTarget !== ev.target) {
             return ev.preventDefault();
           }
@@ -288,8 +288,9 @@ https://github.com/layerssss/paste.js
                   break;
                 }
                 if (item.type === 'text/plain') {
-                  if (_i === 0 && clipboardData.items.length > 1 && clipboardData.items[_i + 1].type.match(/^image\//)) {
+                  if (_i === 0 && clipboardData.items.length > 1 && clipboardData.items[1].type.match(/^image\//)) {
                     stringIsFilename = true;
+                    fileType = clipboardData.items[1].type;
                   }
                   item.getAsString(function(string) {
                     if (stringIsFilename) {
@@ -297,6 +298,7 @@ https://github.com/layerssss/paste.js
                       return _this._target.trigger('pasteText', {
                         text: string,
                         isFilename: true,
+                        fileType: fileType,
                         originalEvent: _this.originalEvent
                       });
                     } else {

--- a/paste.js
+++ b/paste.js
@@ -271,7 +271,7 @@ https://github.com/layerssss/paste.js
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
-                    return _this._handleImage(event.target.result);
+                    return _this._handleImage(event.target.result, (ev.originalEvent !== null ? ev.originalEvent : null));
                   };
                   try {
                     reader.readAsDataURL(item.getAsFile());
@@ -282,7 +282,8 @@ https://github.com/layerssss/paste.js
                 if (item.type === 'text/plain') {
                   item.getAsString(function(string) {
                     return _this._target.trigger('pasteText', {
-                      text: string
+                      text: string,
+                      originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                     });
                   });
                 }
@@ -292,12 +293,13 @@ https://github.com/layerssss/paste.js
                 text = clipboardData.getData('Text');
                 setTimeout(function() {
                   return _this._target.trigger('pasteText', {
-                    text: text
+                    text: text,
+                    originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                   });
                 }, 1);
               }
               _this._checkImagesInContainer(function(src) {
-                return _this._handleImage(src);
+                return _this._handleImage(src, (ev.originalEvent !== null ? ev.originalEvent : null));
               });
             }
           }
@@ -305,7 +307,8 @@ https://github.com/layerssss/paste.js
             if ((ref2 = (text = clipboardData.getData('Text'))) != null ? ref2.length : void 0) {
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
-                  text: text
+                  text: text,
+                  originalEvent: (ev.originalEvent !== null ? ev.originalEvent : null)
                 });
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
@@ -313,7 +316,7 @@ https://github.com/layerssss/paste.js
               ref3 = clipboardData.files;
               for (k = 0, len1 = ref3.length; k < len1; k++) {
                 file = ref3[k];
-                _this._handleImage(URL.createObjectURL(file));
+                _this._handleImage(URL.createObjectURL(file), (ev.originalEvent !== null ? ev.originalEvent : null));
               }
               _this._checkImagesInContainer(function(src) {});
             }
@@ -323,7 +326,7 @@ https://github.com/layerssss/paste.js
       })(this));
     }
 
-    Paste.prototype._handleImage = function(src) {
+    Paste.prototype._handleImage = function(src, e) {
       var loader;
       if (src.match(/^webkit\-fake\-url\:\/\//)) {
         return this._target.trigger('pasteImageError', {
@@ -351,7 +354,8 @@ https://github.com/layerssss/paste.js
               blob: blob,
               dataURL: dataURL,
               width: loader.width,
-              height: loader.height
+              height: loader.height,
+              originalEvent: e
             });
           }
           return _this._target.trigger('pasteImageEnd');


### PR DESCRIPTION
Added some more, based on #55 - added:

- Use pasted text as filename when there's a image included in the paste-event
- Add `pasteTextRich` and `pasteTextHtml` 

Both for Chrome; select a file (in finder / explorer), copy, paste in the browser. 