### PR TITLE
Improved pasting (text, image filename, original event, pasted HTML)

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
       $('.demo-contenteditable').pastableContenteditable();
       $('.demo').on('pasteImage', function(ev, data){
         var blobUrl = URL.createObjectURL(data.blob);
-        $('<div class="result">image: ' + data.width + ' x ' + data.height + '<img src="' + data.dataURL +'" ><a href="' + blobUrl + '">' + blobUrl + '</div>').insertAfter(this);
+        var name = data.name != null ? ', name: ' + data.name : '';
+        $('<div class="result">image: ' + data.width + ' x ' + data.height + name + '<img src="' + data.dataURL +'" ><a href="' + blobUrl + '">' + blobUrl + '</div>').insertAfter(this);
       }).on('pasteImageError', function(ev, data){
         alert('Oops: ' + data.message);
         if(data.url){
@@ -56,6 +57,10 @@
         }
       }).on('pasteText', function(ev, data){
         $('<div class="result"></div>').text('text: "' + data.text + '"').insertAfter(this);
+      }).on('pasteTextRich', function(ev, data){
+        $('<div class="result"></div>').text('rtf: "' + data.text + '"').insertAfter(this);
+      }).on('pasteTextHtml', function(ev, data){
+        $('<div class="result"></div>').text('html: "' + data.text + '"').insertAfter(this);
       });
     });
   </script>

--- a/paste.coffee
+++ b/paste.coffee
@@ -58,6 +58,7 @@ createHiddenEditable = ->
     position: 'fixed'
     left: -100
     overflow: 'hidden'
+    opacity: 1e-17
 
 isFocusable = (element, hasTabindex) ->
   # https://github.com/jquery/jquery-ui/blob/master/ui/focusable.js 
@@ -161,47 +162,66 @@ class Paste
     @_target = $ @_target
       .addClass 'pastable'
     @_container.on 'paste', (ev)=>
-      return ev.preventDefault() unless ev.currentTarget == ev.target
+      # return ev.preventDefault() unless ev.currentTarget == ev.target
+      @originalEvent = (if ev.originalEvent != null then ev.originalEvent else null)
       @_paste_event_fired = true
       if ev.originalEvent?.clipboardData?
         clipboardData = ev.originalEvent.clipboardData
         if clipboardData.items
+          pastedFilename = null
           # Chrome or any other browsers with DataTransfer.items implemented
+          @originalEvent.pastedTypes = []
           for item in clipboardData.items
+            if item.type.match(/^text\/(plain|rtf|html)/) 
+              @originalEvent.pastedTypes.push(item.type)
+          for item, _i in clipboardData.items
             if item.type.match /^image\//
               reader = new FileReader()
               reader.onload = (event)=>
-                @_handleImage event.target.result
+                @_handleImage event.target.result, @originalEvent, pastedFilename
               try
                 reader.readAsDataURL item.getAsFile()
               ev.preventDefault()
               break
             if item.type == 'text/plain'
+              if _i == 0 && clipboardData.items.length > 1 && clipboardData.items[1].type.match /^image\//
+                stringIsFilename = true
+                fileType = clipboardData.items[1].type
               item.getAsString (string)=>
-                @_target.trigger 'pasteText', text: string
+                if stringIsFilename
+                  pastedFilename = string
+                  @_target.trigger 'pasteText', text: string, isFilename: true, fileType: fileType, originalEvent: @originalEvent
+                else
+                  @_target.trigger 'pasteText', text: string, originalEvent: @originalEvent
+            if item.type == 'text/rtf'
+              item.getAsString (string)=>
+                @_target.trigger 'pasteTextRich', text: string, originalEvent: @originalEvent
+            if item.type == 'text/html'
+              item.getAsString (string)=>
+                @_target.trigger 'pasteTextHtml', text: string, originalEvent: @originalEvent
         else
           # Firefox & Safari(text-only)
           if -1 != Array.prototype.indexOf.call clipboardData.types, 'text/plain'
             text = clipboardData.getData 'Text'
             setTimeout =>
-              @_target.trigger 'pasteText', text: text
+              @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             , 1
           @_checkImagesInContainer (src)=>
-            @_handleImage src
+            @_handleImage src, @originalEvent
       # IE
       if clipboardData = window.clipboardData
         if (text = clipboardData.getData 'Text')?.length
           setTimeout =>
-            @_target.trigger 'pasteText', text: text
+            @_target.trigger 'pasteText', text: text, originalEvent: @originalEvent
             @_target.trigger '_pasteCheckContainerDone'
           , 1
         else
           for file in clipboardData.files
-            @_handleImage URL.createObjectURL(file)
+            @_handleImage URL.createObjectURL(file), @originalEvent
           @_checkImagesInContainer (src)->
       null
 
-  _handleImage: (src)->
+  _handleImage: (src, e, name)->
     if src.match /^webkit\-fake\-url\:\/\//
       return @_target.trigger 'pasteImageError',
         message: "You are trying to paste an image in Safari, however we are unable to retieve its data."
@@ -223,7 +243,9 @@ class Paste
           blob: blob
           dataURL: dataURL
           width: loader.width
-          height: loader.height
+          height: loader.height,
+          originalEvent: e,
+          name: name
       @_target.trigger 'pasteImageEnd'
     loader.onerror = =>
       @_target.trigger 'pasteImageError',

--- a/paste.js
+++ b/paste.js
@@ -97,7 +97,8 @@ https://github.com/layerssss/paste.js
       height: 1,
       position: 'fixed',
       left: -100,
-      overflow: 'hidden'
+      overflow: 'hidden',
+      opacity: 1e-17
     });
   };
 
@@ -257,21 +258,28 @@ https://github.com/layerssss/paste.js
       this._target = $(this._target).addClass('pastable');
       this._container.on('paste', (function(_this) {
         return function(ev) {
-          var clipboardData, file, item, j, k, len, len1, reader, ref, ref1, ref2, ref3, text;
-          if (ev.currentTarget !== ev.target) {
-            return ev.preventDefault();
-          }
+          var _i, clipboardData, file, fileType, item, j, k, l, len, len1, len2, pastedFilename, reader, ref, ref1, ref2, ref3, ref4, stringIsFilename, text;
+          _this.originalEvent = (ev.originalEvent !== null ? ev.originalEvent : null);
           _this._paste_event_fired = true;
           if (((ref = ev.originalEvent) != null ? ref.clipboardData : void 0) != null) {
             clipboardData = ev.originalEvent.clipboardData;
             if (clipboardData.items) {
+              pastedFilename = null;
+              _this.originalEvent.pastedTypes = [];
               ref1 = clipboardData.items;
               for (j = 0, len = ref1.length; j < len; j++) {
                 item = ref1[j];
+                if (item.type.match(/^text\/(plain|rtf|html)/)) {
+                  _this.originalEvent.pastedTypes.push(item.type);
+                }
+              }
+              ref2 = clipboardData.items;
+              for (_i = k = 0, len1 = ref2.length; k < len1; _i = ++k) {
+                item = ref2[_i];
                 if (item.type.match(/^image\//)) {
                   reader = new FileReader();
                   reader.onload = function(event) {
-                    return _this._handleImage(event.target.result);
+                    return _this._handleImage(event.target.result, _this.originalEvent, pastedFilename);
                   };
                   try {
                     reader.readAsDataURL(item.getAsFile());
@@ -280,9 +288,40 @@ https://github.com/layerssss/paste.js
                   break;
                 }
                 if (item.type === 'text/plain') {
+                  if (_i === 0 && clipboardData.items.length > 1 && clipboardData.items[1].type.match(/^image\//)) {
+                    stringIsFilename = true;
+                    fileType = clipboardData.items[1].type;
+                  }
                   item.getAsString(function(string) {
-                    return _this._target.trigger('pasteText', {
-                      text: string
+                    if (stringIsFilename) {
+                      pastedFilename = string;
+                      return _this._target.trigger('pasteText', {
+                        text: string,
+                        isFilename: true,
+                        fileType: fileType,
+                        originalEvent: _this.originalEvent
+                      });
+                    } else {
+                      return _this._target.trigger('pasteText', {
+                        text: string,
+                        originalEvent: _this.originalEvent
+                      });
+                    }
+                  });
+                }
+                if (item.type === 'text/rtf') {
+                  item.getAsString(function(string) {
+                    return _this._target.trigger('pasteTextRich', {
+                      text: string,
+                      originalEvent: _this.originalEvent
+                    });
+                  });
+                }
+                if (item.type === 'text/html') {
+                  item.getAsString(function(string) {
+                    return _this._target.trigger('pasteTextHtml', {
+                      text: string,
+                      originalEvent: _this.originalEvent
                     });
                   });
                 }
@@ -292,28 +331,30 @@ https://github.com/layerssss/paste.js
                 text = clipboardData.getData('Text');
                 setTimeout(function() {
                   return _this._target.trigger('pasteText', {
-                    text: text
+                    text: text,
+                    originalEvent: _this.originalEvent
                   });
                 }, 1);
               }
               _this._checkImagesInContainer(function(src) {
-                return _this._handleImage(src);
+                return _this._handleImage(src, _this.originalEvent);
               });
             }
           }
           if (clipboardData = window.clipboardData) {
-            if ((ref2 = (text = clipboardData.getData('Text'))) != null ? ref2.length : void 0) {
+            if ((ref3 = (text = clipboardData.getData('Text'))) != null ? ref3.length : void 0) {
               setTimeout(function() {
                 _this._target.trigger('pasteText', {
-                  text: text
+                  text: text,
+                  originalEvent: _this.originalEvent
                 });
                 return _this._target.trigger('_pasteCheckContainerDone');
               }, 1);
             } else {
-              ref3 = clipboardData.files;
-              for (k = 0, len1 = ref3.length; k < len1; k++) {
-                file = ref3[k];
-                _this._handleImage(URL.createObjectURL(file));
+              ref4 = clipboardData.files;
+              for (l = 0, len2 = ref4.length; l < len2; l++) {
+                file = ref4[l];
+                _this._handleImage(URL.createObjectURL(file), _this.originalEvent);
               }
               _this._checkImagesInContainer(function(src) {});
             }
@@ -323,7 +364,7 @@ https://github.com/layerssss/paste.js
       })(this));
     }
 
-    Paste.prototype._handleImage = function(src) {
+    Paste.prototype._handleImage = function(src, e, name) {
       var loader;
       if (src.match(/^webkit\-fake\-url\:\/\//)) {
         return this._target.trigger('pasteImageError', {
@@ -351,7 +392,9 @@ https://github.com/layerssss/paste.js
               blob: blob,
               dataURL: dataURL,
               width: loader.width,
-              height: loader.height
+              height: loader.height,
+              originalEvent: e,
+              name: name
             });
           }
           return _this._target.trigger('pasteImageEnd');


### PR DESCRIPTION
- Persist pasted image filename (data.name)
    > Reproduce: copy image from OSX finder, paste in Chrome.
    Filename & image are now one paste-event, name is persisted
    with image.
- Added pasteTextRich and pasteTextHtml events for paste-events where one piece of text is pasted from the clipboard in multiple mime-types #56 
    > Reproduce: copy some content from a Chrome tab, and paste it (or use a text editor like MS Word / Apple Pages)
- Don't display the paste-div: when pasting large HTML content, the content can overflow the paste-div (if CSS in the pasted content is present enforcing fixed positioning). Now hidden 'opacity' to prevent the pasted content showing.
- Original paste-event is appended to PasteJS events. Can be used to retrieve original information, or append custom information in the generic "paste" method, to access the content in the mime-type specific paste events (pasteText, etc.) #55 